### PR TITLE
Add requirement for plyfile and ipdb

### DIFF
--- a/nerfgs/pyproject.toml
+++ b/nerfgs/pyproject.toml
@@ -3,7 +3,7 @@ name = "nerfgs"
 description = "nerfgs: convert nerfsh to gs"
 version = "0.1.0"
 
-dependencies = ["nerfstudio >= 0.3.0", "plyfile >= 1.0.3"] 
+dependencies = ["nerfstudio >= 0.3.0", "plyfile >= 1.0.3", "ipdb >= 0.13.13"] 
 
 [tool.setuptools.packages.find]
 include = ["nerfgs*"]

--- a/nerfgs/pyproject.toml
+++ b/nerfgs/pyproject.toml
@@ -3,7 +3,7 @@ name = "nerfgs"
 description = "nerfgs: convert nerfsh to gs"
 version = "0.1.0"
 
-dependencies = ["nerfstudio >= 0.3.0"] 
+dependencies = ["nerfstudio >= 0.3.0", "plyfile >= 1.0.3"] 
 
 [tool.setuptools.packages.find]
 include = ["nerfgs*"]

--- a/nerfsh/pyproject.toml
+++ b/nerfsh/pyproject.toml
@@ -3,7 +3,7 @@ name = "nerfsh"
 description = "nerfsh: nerf with spherical harmonics output."
 version = "0.1.0"
 
-dependencies = ["nerfstudio >= 0.3.0", "plyfile >= 1.0.3"] 
+dependencies = ["nerfstudio >= 0.3.0", "plyfile >= 1.0.3", "ipdb >= 0.13.13"] 
 
 [tool.setuptools.packages.find]
 include = ["nerfsh*"]

--- a/nerfsh/pyproject.toml
+++ b/nerfsh/pyproject.toml
@@ -3,7 +3,7 @@ name = "nerfsh"
 description = "nerfsh: nerf with spherical harmonics output."
 version = "0.1.0"
 
-dependencies = ["nerfstudio >= 0.3.0"] 
+dependencies = ["nerfstudio >= 0.3.0", "plyfile >= 1.0.3"] 
 
 [tool.setuptools.packages.find]
 include = ["nerfsh*"]


### PR DESCRIPTION
At `nerfstudio/pyproject.toml`, it does not have dependencies of `plyfile` and `ipdb`.

This cause `ns-install-cli` failed with this error:
![image](https://github.com/grasp-lyrl/NeRFtoGSandBack/assets/60387342/7bacef71-4c90-4437-8b6d-14d8b1ba7573)

So, I add that requirement for this repo. Now it runs properly.
![image](https://github.com/grasp-lyrl/NeRFtoGSandBack/assets/60387342/b88ed419-e271-455e-a083-e9cd9d25933f)
